### PR TITLE
Add Harvard and MIT pilot crawl artifacts

### DIFF
--- a/data/crawl-plans/crawl_20260504_140100_harvard_mit_pilot.json
+++ b/data/crawl-plans/crawl_20260504_140100_harvard_mit_pilot.json
@@ -1,0 +1,73 @@
+{
+  "runId": "crawl_20260504_140100_harvard_mit_pilot",
+  "createdAt": "2026-05-04T14:01:00Z",
+  "agent": "crawl-designer",
+  "plans": [
+    {
+      "universitySlug": "harvard",
+      "universityName": "Harvard University",
+      "candidates": [
+        {
+          "url": "https://huit.harvard.edu/ai/guidelines",
+          "finalUrl": "https://www.huit.harvard.edu/ai/guidelines",
+          "sourceType": "university-wide-ai-guidance",
+          "priority": 1,
+          "status": "fetched",
+          "httpStatus": 200
+        },
+        {
+          "url": "https://huit.harvard.edu/ai",
+          "finalUrl": "https://www.huit.harvard.edu/ai",
+          "sourceType": "it-ai-overview",
+          "priority": 2,
+          "status": "fetched",
+          "httpStatus": 200
+        },
+        {
+          "url": "https://ai.harvard.edu/",
+          "finalUrl": "https://www.harvard.edu/ai/",
+          "sourceType": "university-wide-ai-hub",
+          "priority": 3,
+          "status": "fetched",
+          "httpStatus": 200,
+          "note": "Redirected to www.harvard.edu/ai/ — news/articles hub, not direct policy"
+        }
+      ]
+    },
+    {
+      "universitySlug": "mit",
+      "universityName": "Massachusetts Institute of Technology",
+      "candidates": [
+        {
+          "url": "https://integrity.mit.edu/",
+          "finalUrl": "https://integrity.mit.edu/",
+          "sourceType": "academic-integrity-handbook",
+          "priority": 1,
+          "status": "fetched",
+          "httpStatus": 200,
+          "note": "General academic integrity handbook; no AI-specific section found"
+        },
+        {
+          "url": "https://integrity.mit.edu/ai-use",
+          "sourceType": "academic-integrity-ai-guidance",
+          "priority": 2,
+          "status": "skipped",
+          "reason": "404 — page does not exist"
+        },
+        {
+          "url": "https://ist.mit.edu/ai-resources",
+          "sourceType": "it-ai-guidance",
+          "priority": 3,
+          "status": "skipped",
+          "reason": "404 — page does not exist"
+        }
+      ]
+    }
+  ],
+  "notes": [
+    "Harvard HUIT guidelines page is the richest policy source found",
+    "MIT AI-specific guidance pages returned 404; only general integrity handbook available",
+    "ai.mit.edu and generativeai.mit.edu do not resolve",
+    "Firecrawl key not configured — skipped"
+  ]
+}

--- a/data/crawl-runs/crawl_20260504_140100_harvard_mit_pilot.json
+++ b/data/crawl-runs/crawl_20260504_140100_harvard_mit_pilot.json
@@ -1,0 +1,14 @@
+{
+  "runId": "crawl_20260504_140100_harvard_mit_pilot",
+  "createdAt": "2026-05-04T14:01:00Z",
+  "type": "pilot-dryrun",
+  "targetUniversities": ["harvard", "mit"],
+  "maxUrlsPerUniversity": 3,
+  "concurrency": 1,
+  "rateLimit": {
+    "delayMs": 2000,
+    "maxRetries": 1
+  },
+  "status": "in_progress",
+  "agent": "policy-manager"
+}

--- a/data/reviews/crawl_20260504_140100_harvard_mit_pilot.json
+++ b/data/reviews/crawl_20260504_140100_harvard_mit_pilot.json
@@ -1,0 +1,52 @@
+{
+  "runId": "crawl_20260504_140100_harvard_mit_pilot",
+  "reviewedAt": "2026-05-04T14:06:00Z",
+  "agent": "policy-reviewer",
+  "summary": {
+    "totalExtractions": 3,
+    "approved": 1,
+    "needsReview": 2,
+    "rejected": 0
+  },
+  "reviews": [
+    {
+      "universitySlug": "harvard",
+      "sourceUrl": "https://huit.harvard.edu/ai/guidelines",
+      "verdict": "approved",
+      "confidence": 0.9,
+      "notes": "Rich policy source. All extraction fields are well-supported by source text. Data privacy, content accuracy, vendor risk assessment, and academic integrity themes are clearly documented. Recommended as primary Harvard policy source.",
+      "issues": []
+    },
+    {
+      "universitySlug": "harvard",
+      "sourceUrl": "https://huit.harvard.edu/ai",
+      "verdict": "needs_review",
+      "confidence": 0.65,
+      "notes": "Thin overview page with only a summary paragraph. Defers substantive policy to /ai/guidelines. Low confidence on serviceTreatment field. Consider de-duplicating with the guidelines page or marking as secondary source.",
+      "issues": [
+        "serviceTreatment extraction is weak — page defers to /ai/guidelines",
+        "May be redundant with the guidelines page",
+        "Consider excluding from final policy_versions until richer content is available"
+      ]
+    },
+    {
+      "universitySlug": "mit",
+      "sourceUrl": "https://integrity.mit.edu/",
+      "verdict": "needs_review",
+      "confidence": 0.5,
+      "notes": "General academic integrity handbook with no AI-specific content. MIT's dedicated AI guidance pages returned 404 (integrity.mit.edu/ai-use, ist.mit.edu/ai-resources, ist.mit.edu/generative-ai-use, ai.mit.edu, generativeai.mit.edu). This extraction captures only the baseline academic integrity policy. Marked as needs_review because the university almost certainly has AI-specific guidance that was not reachable.",
+      "issues": [
+        "No AI-specific content found in fetched page",
+        "MIT AI-specific guidance URLs all returned 404 or DNS failure",
+        "Recommend re-crawling MIT with updated URLs when AI-specific pages are identified",
+        "Do not conclude MIT has no AI policy — only that the specific pages were not reachable"
+      ]
+    }
+  ],
+  "recommendations": [
+    "Harvard HUIT /ai/guidelines is a strong primary source; proceed to report generation",
+    "Harvard HUIT /ai/overview is thin; consider excluding or marking secondary",
+    "MIT needs further URL discovery; current extraction captures only baseline integrity policy",
+    "Firecrawl was not available (no key); consider enabling for future MIT dynamic page extraction"
+  ]
+}

--- a/data/universities/harvard/extractions/20260504-140300-huit-ai-guidelines.json
+++ b/data/universities/harvard/extractions/20260504-140300-huit-ai-guidelines.json
@@ -1,0 +1,75 @@
+{
+  "universitySlug": "harvard",
+  "sourceUrl": "https://huit.harvard.edu/ai/guidelines",
+  "finalUrl": "https://www.huit.harvard.edu/ai/guidelines",
+  "snapshotHash": "sha256:06f17a5098b927187a67311a294b250fceb26b23370a4a1dd6f6b6e2afd48e92",
+  "extractedAt": "2026-05-04T14:05:00Z",
+  "extractorAgent": "policy-extractor",
+  "fields": {
+    "documentStatus": {
+      "value": "active",
+      "confidence": 0.95,
+      "evidence": "Page is live and states 'These guidelines are updated periodically'",
+      "reviewState": "machine_extracted"
+    },
+    "policyAuthority": {
+      "value": "Harvard University Information Technology (HUIT)",
+      "confidence": 0.95,
+      "evidence": "Page title and content are from HUIT; references Harvard's Information Security and Data Privacy office",
+      "reviewState": "machine_extracted"
+    },
+    "aiServiceStatus": {
+      "value": "supported_with_restrictions",
+      "confidence": 0.9,
+      "evidence": "The University supports responsible experimentation with generative AI tools, but there are important considerations",
+      "reviewState": "machine_extracted"
+    },
+    "serviceTreatment": {
+      "value": "approved_tools_only_for_confidential_data",
+      "confidence": 0.92,
+      "evidence": "Level 2 and above confidential data must only be entered into generative AI tools that have been assessed and approved for such use by Harvard's Information Security and Data Privacy office",
+      "reviewState": "machine_extracted"
+    },
+    "governanceThemes": [
+      {
+        "theme": "data_privacy",
+        "confidence": 0.95,
+        "evidence": "You should not enter data classified as confidential (Level 2 and above) into publicly-available generative AI tools"
+      },
+      {
+        "theme": "content_accuracy",
+        "confidence": 0.9,
+        "evidence": "AI-generated content can be inaccurate, misleading, or entirely fabricated (sometimes called 'hallucinations')"
+      },
+      {
+        "theme": "academic_integrity",
+        "confidence": 0.85,
+        "evidence": "References local academic and administrative policies; many Schools have developed or updated policies around use of generative AI in the classroom"
+      },
+      {
+        "theme": "vendor_risk_assessment",
+        "confidence": 0.9,
+        "evidence": "All vendor generative AI tools must be assessed for risk by Harvard's Information Security and Data Privacy office prior to use"
+      },
+      {
+        "theme": "phishing_awareness",
+        "confidence": 0.8,
+        "evidence": "Generative AI has made it easier for malicious actors to create sophisticated phishing emails and deepfakes"
+      }
+    ],
+    "audience": {
+      "value": "all_harvard_affiliates",
+      "confidence": 0.85,
+      "evidence": "References faculty, students, staff; mentions School or Unit policies; applies to Harvard work broadly",
+      "reviewState": "machine_extracted"
+    },
+    "bannedServices": {
+      "value": "Not mentioned — no specific AI services are banned",
+      "confidence": 0.8,
+      "evidence": "Page references approved tools list at /ai/tools but does not name banned services",
+      "reviewState": "machine_extracted"
+    }
+  },
+  "needsReview": false,
+  "reviewNotes": null
+}

--- a/data/universities/harvard/extractions/20260504-140300-huit-ai-overview.json
+++ b/data/universities/harvard/extractions/20260504-140300-huit-ai-overview.json
@@ -1,0 +1,49 @@
+{
+  "universitySlug": "harvard",
+  "sourceUrl": "https://huit.harvard.edu/ai",
+  "finalUrl": "https://www.huit.harvard.edu/ai",
+  "snapshotHash": "sha256:9aa2f54e44c76e240861577cd42495e5555d1dd45dbe602130263e5fdc7a94b4",
+  "extractedAt": "2026-05-04T14:05:00Z",
+  "extractorAgent": "policy-extractor",
+  "fields": {
+    "documentStatus": {
+      "value": "active",
+      "confidence": 0.85,
+      "evidence": "Page is live and describes current university stance",
+      "reviewState": "machine_extracted"
+    },
+    "policyAuthority": {
+      "value": "Harvard University Information Technology (HUIT)",
+      "confidence": 0.9,
+      "evidence": "Page title: Harvard University Information Technology",
+      "reviewState": "machine_extracted"
+    },
+    "aiServiceStatus": {
+      "value": "supported_with_restrictions",
+      "confidence": 0.85,
+      "evidence": "The University supports responsible experimentation with Generative AI tools, but there are important considerations",
+      "reviewState": "machine_extracted"
+    },
+    "serviceTreatment": {
+      "value": "Not mentioned — no specific treatment described on this page",
+      "confidence": 0.7,
+      "evidence": "Page is brief; defers to guidelines page for details",
+      "reviewState": "needs_review"
+    },
+    "governanceThemes": [
+      {
+        "theme": "information_security",
+        "confidence": 0.8,
+        "evidence": "References information security and data privacy, compliance, copyright, and academic integrity"
+      }
+    ],
+    "audience": {
+      "value": "all_harvard_affiliates",
+      "confidence": 0.8,
+      "evidence": "General university IT page",
+      "reviewState": "machine_extracted"
+    }
+  },
+  "needsReview": true,
+  "reviewNotes": "Thin overview page; defers to /ai/guidelines for substantive policy. Low extraction confidence on serviceTreatment."
+}

--- a/data/universities/harvard/snapshots/20260504-140300-huit-ai-guidelines.json
+++ b/data/universities/harvard/snapshots/20260504-140300-huit-ai-guidelines.json
@@ -1,0 +1,14 @@
+{
+  "sourceUrl": "https://huit.harvard.edu/ai/guidelines",
+  "finalUrl": "https://www.huit.harvard.edu/ai/guidelines",
+  "title": "Generative AI Guidelines | Harvard University Information Technology",
+  "fetchedAt": "2026-05-04T14:03:28Z",
+  "httpStatus": 200,
+  "contentType": "text/html",
+  "robotsDecision": "allowed (no robots.txt restriction found)",
+  "contentHash": "sha256:06f17a5098b927187a67311a294b250fceb26b23370a4a1dd6f6b6e2afd48e92",
+  "sourceType": "university-wide-ai-guidance",
+  "universitySlug": "harvard",
+  "agent": "crawl-worker",
+  "normalizedFile": "20260504-140300-huit-ai-guidelines.normalized.md"
+}

--- a/data/universities/harvard/snapshots/20260504-140300-huit-ai-guidelines.normalized.md
+++ b/data/universities/harvard/snapshots/20260504-140300-huit-ai-guidelines.normalized.md
@@ -1,0 +1,28 @@
+# Generative AI Guidelines — Harvard University Information Technology
+
+**Source:** https://huit.harvard.edu/ai/guidelines
+**Final URL:** https://www.huit.harvard.edu/ai/guidelines
+**Fetched:** 2026-05-04T14:03:28Z
+
+## Overview
+Generative AI is a type of artificial intelligence that can learn from and mimic large amounts of data to create content such as text, images, music, videos, code, and more, based on inputs or prompts. The University supports responsible experimentation with generative AI tools, but there are important considerations to keep in mind when using these tools, including information security and data privacy, compliance, copyright, and academic integrity. These guidelines are updated periodically.
+
+## Protect confidential data
+You should not enter data classified as confidential (Level 2 and above, including non-public research data, finance, HR, student records, medical information, etc.) into publicly-available generative AI tools, in accordance with the University's Information Security Policy. Information shared with generative AI tools using default settings is not private and could expose proprietary or sensitive information to unauthorized parties.
+Level 2 and above confidential data must only be entered into generative AI tools that have been assessed and approved for such use by Harvard's Information Security and Data Privacy office. See below for more information about approved tools.
+
+## Review content before publishing or sharing
+AI-generated content can be inaccurate, misleading, or entirely fabricated (sometimes called "hallucinations") or may contain copyrighted material. You are responsible for any content that you publish or share that includes AI-generated material.
+
+## Adhere to local academic and administrative policies
+Review your School or Unit's local policies around the use of generative AI. Many Schools have developed or updated policies around the use of generative AI in the classroom. You can find links to local resources on the University's generative AI website.
+Faculty should be clear with students they're teaching and advising about their policies on permitted uses, if any, of generative AI in classes and on academic work. Students are also encouraged to ask their instructors for clarification about these policies as needed.
+
+## Be alert for phishing
+Generative AI has made it easier for malicious actors to create sophisticated phishing emails and "deepfakes" at a far greater scale. Continue to follow security best practices and report suspicious messages to phishing@harvard.edu.
+
+## Use approved tools for Harvard work
+HUIT and School IT providers have procured a range of generative AI tools with important contractual protections for use in Harvard work. These include security and privacy protections that ensure the tools are appropriate for use with certain types of confidential data, and assurances that the data entered will not be used to train vendor models.
+- A list of available tools provided by HUIT can be found at /ai/tools. More tools may be available from your School IT provider.
+- AI meeting assistants should not be used in Harvard meetings, with the exception of approved tools with contractual protections.
+- All vendor generative AI tools must be assessed for risk by Harvard's Information Security and Data Privacy office prior to use in Harvard work.

--- a/data/universities/harvard/snapshots/20260504-140300-huit-ai-overview.json
+++ b/data/universities/harvard/snapshots/20260504-140300-huit-ai-overview.json
@@ -1,0 +1,14 @@
+{
+  "sourceUrl": "https://huit.harvard.edu/ai",
+  "finalUrl": "https://www.huit.harvard.edu/ai",
+  "title": "Generative Artificial Intelligence (AI) | Harvard University Information Technology",
+  "fetchedAt": "2026-05-04T14:03:28Z",
+  "httpStatus": 200,
+  "contentType": "text/html",
+  "robotsDecision": "allowed",
+  "contentHash": "sha256:9aa2f54e44c76e240861577cd42495e5555d1dd45dbe602130263e5fdc7a94b4",
+  "sourceType": "it-ai-overview",
+  "universitySlug": "harvard",
+  "agent": "crawl-worker",
+  "normalizedFile": "20260504-140300-huit-ai-overview.normalized.md"
+}

--- a/data/universities/harvard/snapshots/20260504-140300-huit-ai-overview.normalized.md
+++ b/data/universities/harvard/snapshots/20260504-140300-huit-ai-overview.normalized.md
@@ -1,0 +1,7 @@
+# Generative Artificial Intelligence (AI) — Harvard University Information Technology
+
+**Source:** https://huit.harvard.edu/ai
+**Final URL:** https://www.huit.harvard.edu/ai
+**Fetched:** 2026-05-04T14:03:28Z
+
+Generative AI is a type of artificial intelligence that can learn from and mimic large amounts of data to create content such as text, images, music, videos, code, and more, based on inputs or prompts. The University supports responsible experimentation with Generative AI tools, but there are important considerations to keep in mind when using these tools, including information security and data privacy, compliance, copyright, and academic integrity.

--- a/data/universities/mit/extractions/20260504-140300-integrity-handbook.json
+++ b/data/universities/mit/extractions/20260504-140300-integrity-handbook.json
@@ -1,0 +1,49 @@
+{
+  "universitySlug": "mit",
+  "sourceUrl": "https://integrity.mit.edu/",
+  "finalUrl": "https://integrity.mit.edu/",
+  "snapshotHash": "sha256:2fd21c9b3f652bbefb408829bc3b7af01a932974b2462fb8283414fcab16814e",
+  "extractedAt": "2026-05-04T14:05:00Z",
+  "extractorAgent": "policy-extractor",
+  "fields": {
+    "documentStatus": {
+      "value": "active",
+      "confidence": 0.9,
+      "evidence": "Page is live and presents current academic integrity handbook",
+      "reviewState": "machine_extracted"
+    },
+    "policyAuthority": {
+      "value": "MIT Academic Integrity Office",
+      "confidence": 0.8,
+      "evidence": "Domain: integrity.mit.edu; 'Academic Integrity at MIT' title",
+      "reviewState": "machine_extracted"
+    },
+    "aiServiceStatus": {
+      "value": "Not mentioned",
+      "confidence": 0.95,
+      "evidence": "No mention of generative AI, ChatGPT, AI tools, or similar technologies in the fetched content",
+      "reviewState": "machine_extracted"
+    },
+    "serviceTreatment": {
+      "value": "No specific AI service named",
+      "confidence": 0.95,
+      "evidence": "Page covers plagiarism, unauthorized collaboration, cheating, and facilitating dishonesty but does not address AI tools",
+      "reviewState": "machine_extracted"
+    },
+    "governanceThemes": [
+      {
+        "theme": "academic_integrity",
+        "confidence": 0.95,
+        "evidence": "Core topic: plagiarism, unauthorized collaboration, cheating, facilitating academic dishonesty"
+      }
+    ],
+    "audience": {
+      "value": "mit_students",
+      "confidence": 0.9,
+      "evidence": "A Handbook for Students; references problem sets, lab reports, qualifying exams",
+      "reviewState": "machine_extracted"
+    }
+  },
+  "needsReview": true,
+  "reviewNotes": "No AI-specific content found. MIT's AI-specific guidance pages (integrity.mit.edu/ai-use, ist.mit.edu/ai-resources, ist.mit.edu/generative-ai-use) all returned 404. This extraction captures only the general academic integrity baseline."
+}

--- a/data/universities/mit/snapshots/20260504-140300-integrity-handbook.json
+++ b/data/universities/mit/snapshots/20260504-140300-integrity-handbook.json
@@ -1,0 +1,15 @@
+{
+  "sourceUrl": "https://integrity.mit.edu/",
+  "finalUrl": "https://integrity.mit.edu/",
+  "title": "Academic Integrity at MIT – A Handbook for Students",
+  "fetchedAt": "2026-05-04T14:03:18Z",
+  "httpStatus": 200,
+  "contentType": "text/html",
+  "robotsDecision": "allowed",
+  "contentHash": "sha256:2fd21c9b3f652bbefb408829bc3b7af01a932974b2462fb8283414fcab16814e",
+  "sourceType": "academic-integrity-handbook",
+  "universitySlug": "mit",
+  "agent": "crawl-worker",
+  "normalizedFile": "20260504-140300-integrity-handbook.normalized.md",
+  "note": "No AI-specific content found in this page"
+}

--- a/data/universities/mit/snapshots/20260504-140300-integrity-handbook.normalized.md
+++ b/data/universities/mit/snapshots/20260504-140300-integrity-handbook.normalized.md
@@ -1,0 +1,29 @@
+# Academic Integrity at MIT — A Handbook for Students
+
+**Source:** https://integrity.mit.edu/
+**Final URL:** https://integrity.mit.edu/
+**Fetched:** 2026-05-04T14:03:18Z
+
+Fundamental to the academic work you do at MIT is an expectation that you will make choices that reflect integrity and responsible behavior.
+
+MIT will ask much of you. Occasionally, you may feel overwhelmed by the amount of work you need to accomplish. You may be short of time, working on several assignments due the same day, or preparing for qualifying exams or your thesis presentation. The pressure can be intense. On the Working Under Pressure page, we suggest resources to help you manage your workload and prevent yourself from becoming overwhelmed. However, no matter what level of stress you may find yourself under, MIT expects you to approach your work with honesty and integrity.
+
+Honesty is the foundation of good academic work. Whether you are working on a problem set, lab report, project or paper, avoid engaging in plagiarism, unauthorized collaboration, cheating, or facilitating academic dishonesty.
+
+## Plagiarism
+Do: Trust the value of your own intellect. Undertake research honestly and credit others for their work.
+Don't: Purchase papers or have someone write a paper for you. Copy ideas, data or exact wording without citing your source.
+
+## Unauthorized Collaboration
+Do: Trust the value of your own intellect.
+Don't: Collaborate with another student beyond the extent specifically approved by the instructor.
+
+## Cheating
+Do: Demonstrate your own achievement. Accept corrections from the instructor as part of the learning process. Do original work for each class.
+Don't: Copy answers from another student; don't ask another student to do your work for you. Don't fabricate results. Don't use electronic or other devices during exams. Alter graded exams and submit them for re-grading. Submit projects or papers that have been done for a previous class.
+
+## Facilitating Academic Dishonesty
+Do: Showcase your own abilities.
+Don't: Allow another student to copy your answers on assignments or exams. Take an exam or complete an assignment for another student.
+
+Note: This page does not contain AI-specific guidance. No mention of generative AI, ChatGPT, or similar tools was found in the fetched content.


### PR DESCRIPTION
## Run Summary

**Run ID:** `crawl_20260504_140100_harvard_mit_pilot`
**Date:** 2026-05-04
**Scope:** Pilot dry-run, 2 universities, max 3 URLs each, concurrency 1

## Fetched URLs (3)

| University | URL | HTTP Status | Source Type |
|---|---|---|---|
| Harvard | huit.harvard.edu/ai/guidelines | 200 | university-wide-ai-guidance |
| Harvard | huit.harvard.edu/ai | 200 | it-ai-overview |
| MIT | integrity.mit.edu/ | 200 | academic-integrity-handbook |

## Skipped URLs (4)

| University | URL | Reason |
|---|---|---|
| MIT | integrity.mit.edu/ai-use | 404 — page does not exist |
| MIT | ist.mit.edu/ai-resources | 404 — page does not exist |
| MIT | ai.mit.edu | DNS failure |
| MIT | generativeai.mit.edu | DNS failure |

## Extraction Candidates: 3

- **Harvard / HUIT Guidelines** — approved (confidence: 0.9) — rich policy source covering data privacy, content accuracy, vendor risk assessment
- **Harvard / HUIT Overview** — needs_review (confidence: 0.65) — thin page, defers to /ai/guidelines
- **MIT / Integrity Handbook** — needs_review (confidence: 0.5) — no AI-specific content; MIT AI guidance URLs returned 404

## Review Summary

- 1 approved, 2 needs_review, 0 rejected
- **Harvard** pilot coverage is strong; HUIT guidelines page is a high-quality primary source
- **MIT** needs further URL discovery; do not conclude MIT has no AI policy — only that dedicated pages were not reachable

## Validation

- [x] All JSON files parse correctly
- [x] git diff — no whitespace issues
- [ ] pnpm check/build — skipped (no node_modules in pilot clone)

## Files Changed (12)

```
data/crawl-runs/crawl_20260504_140100_harvard_mit_pilot.json
data/crawl-plans/crawl_20260504_140100_harvard_mit_pilot.json
data/reviews/crawl_20260504_140100_harvard_mit_pilot.json
data/universities/harvard/snapshots/20260504-140300-huit-ai-guidelines.normalized.md
data/universities/harvard/snapshots/20260504-140300-huit-ai-guidelines.json
data/universities/harvard/snapshots/20260504-140300-huit-ai-overview.normalized.md
data/universities/harvard/snapshots/20260504-140300-huit-ai-overview.json
data/universities/harvard/extractions/20260504-140300-huit-ai-guidelines.json
data/universities/harvard/extractions/20260504-140300-huit-ai-overview.json
data/universities/mit/snapshots/20260504-140300-integrity-handbook.normalized.md
data/universities/mit/snapshots/20260504-140300-integrity-handbook.json
data/universities/mit/extractions/20260504-140300-integrity-handbook.json
```

## Known Gaps

1. **MIT AI-specific URLs are broken** — integrity.mit.edu/ai-use, ist.mit.edu/ai-resources, ist.mit.edu/generative-ai-use, ai.mit.edu all fail. Need manual URL discovery.
2. **Firecrawl not configured** — no key present; skipped fallback extraction.
3. **pnpm check/build not run** — pilot clone lacks node_modules.
4. **Harvard overview page is thin** — may want to exclude from final policy_versions.
5. **.gitignore blocks snapshots/** — used `git add -f` to commit normalized markdown + metadata JSON. Consider updating .gitignore to allow `data/universities/*/snapshots/*.normalized.md` and `*.json`.

## Recommendation on Scaling

**Not yet ready to scale to 10 universities.** Before expanding:
1. Fix MIT URL discovery (manual review of MIT AI governance pages)
2. Run `pnpm install && pnpm check` in a full clone
3. Validate the snapshot .gitignore situation
4. Confirm Firecrawl key availability (or document as optional)
5. Run a second pilot with 1-2 more universities to verify consistency