### PR TITLE
Handle completed maintenance reviews with notes

### DIFF
--- a/scripts/collect-maintenance-review-results.ts
+++ b/scripts/collect-maintenance-review-results.ts
@@ -35,10 +35,7 @@ async function main(): Promise<void> {
   const prefix = `uapt-maintenance-light-${sanitize(runId)}-`;
   const byItem = new Map<string, PendingResult>();
 
-  for (const file of [
-    ...(await files(path.join(base, "notes"))),
-    ...(await files(path.join(base, "logs"))),
-  ]) {
+  for (const file of await files(path.join(base, "logs"))) {
     const text = await readFile(file, "utf8");
     const item = path.basename(file, path.extname(file));
     mergeResult(byItem, {
@@ -46,6 +43,17 @@ async function main(): Promise<void> {
       classification: classifyNoteOrLog(text),
       detail: "Note/log only; no publishable conclusion inferred.",
       priority: 10,
+    });
+  }
+
+  for (const file of await files(path.join(base, "notes"))) {
+    const text = await readFile(file, "utf8");
+    const item = path.basename(file, path.extname(file));
+    mergeResult(byItem, {
+      item,
+      classification: classifyNoteOrLog(text),
+      detail: "Maintenance note only; no publishable conclusion inferred.",
+      priority: 20,
     });
   }
 
@@ -128,7 +136,7 @@ async function main(): Promise<void> {
 
 function mergeResult(results: Map<string, PendingResult>, result: PendingResult): void {
   const current = results.get(result.item);
-  if (!current || result.priority >= current.priority) {
+  if (!current || result.priority > current.priority) {
     results.set(result.item, result);
   }
 }

--- a/scripts/start-lightweight-maintenance-review.ts
+++ b/scripts/start-lightweight-maintenance-review.ts
@@ -109,7 +109,9 @@ function startTarget(
 
   const command = retryCommand({
     ...options,
+    artifactDir,
     logFile,
+    noteFile,
     promptFile,
     sessionId,
   });
@@ -151,7 +153,9 @@ function startTarget(
 
 function retryCommand(
   input: Options & {
+    artifactDir: string;
     logFile: string;
+    noteFile: string;
     promptFile: string;
     sessionId: string;
   },
@@ -171,6 +175,7 @@ function retryCommand(
     "      exit 0",
     "    fi",
     "    code=$?",
+    `    if [ -s ${quote(input.noteFile)} ] || [ -s ${quote(path.join(input.artifactDir, "artifacts.json"))} ]; then echo "model=$model attempt=$attempt result_written_after_nonzero_exit=$code" >> ${quote(input.logFile)}; exit 0; fi`,
     `    if tail -n 24 ${quote(input.logFile)} | grep -Eqi ${quote(TRANSIENT_PATTERN)}; then klass=transient; else klass=permanent; fi`,
     `    echo "model=$model attempt=$attempt error_class=$klass exit=$code" >> ${quote(input.logFile)}`,
     '    [ "$klass" = transient ] || break',


### PR DESCRIPTION
## Summary
- treat a nonzero OpenClaw exit as completed when a maintenance note or artifact was written
- prioritize maintenance notes over noisy raw logs in result collection while keeping artifact validation highest priority

## Verification
- pnpm exec tsc --noEmit --pretty false --target ES2022 --module NodeNext --moduleResolution NodeNext --types node scripts/start-lightweight-maintenance-review.ts scripts/collect-maintenance-review-results.ts
- local collector simulation with a note plus noisy gateway log returns no_promote
- launcher dry-run shows result_written_after_nonzero_exit guard