### PR TITLE
fix: use public canonical URLs in snapshot API

### DIFF
--- a/apps/web/lib/policy-snapshots.ts
+++ b/apps/web/lib/policy-snapshots.ts
@@ -140,12 +140,17 @@ export function buildPolicySnapshotResponse(
   generatedAt = new Date().toISOString()
 ): PolicySnapshotResponse {
   const snapshot = loaded.snapshot;
+  const canonicalUrl = new URL(
+    `/universities/${snapshot.universitySlug}`,
+    siteBaseUrl
+  ).toString();
   const publicJsonUrl = new URL(
     `/api/public/${PUBLIC_API_VERSION}/policy-snapshots/universities/${snapshot.universitySlug}.json`,
     siteBaseUrl
   ).toString();
   const data = policySnapshotSchema.parse({
     ...snapshot,
+    canonicalUrl,
     overallStatus: loaded.validation.effectiveStatus,
     statusReasons:
       loaded.validation.effectiveStatus === "strong"
@@ -159,7 +164,7 @@ export function buildPolicySnapshotResponse(
   return policySnapshotResponseSchema.parse({
     apiVersion: PUBLIC_API_VERSION,
     generatedAt,
-    canonicalUrl: snapshot.canonicalUrl,
+    canonicalUrl,
     license: TRACKER_METADATA_LICENSE,
     trackerMetadataLicense: TRACKER_METADATA_LICENSE,
     sourcePolicy: OFFICIAL_SOURCE_RIGHTS_CAVEAT,
@@ -169,11 +174,11 @@ export function buildPolicySnapshotResponse(
       : [NO_ADVICE_BOUNDARY],
     citation: buildPublicApiCitation({
       citationTitle: `${snapshot.universityName} student policy snapshot`,
-      canonicalUrl: snapshot.canonicalUrl,
+      canonicalUrl,
       publicJsonUrl,
       suggestedCitation:
         `University AI Policy Tracker. "${snapshot.universityName} student policy snapshot." ` +
-        `Version ${POLICY_SNAPSHOT_SCHEMA_VERSION}. ${snapshot.canonicalUrl}`
+        `Version ${POLICY_SNAPSHOT_SCHEMA_VERSION}. ${canonicalUrl}`
     }),
     data
   });


### PR DESCRIPTION
## Summary

Follow-up to #11: fix the public `uapt-policy-snapshot-v1` response so `canonicalUrl` and the suggested citation use the configured public site base URL instead of the authoring fixture's localhost URL.

This is a narrow deterministic public-API URL mapping fix observed during post-deploy verification. It does not change Snapshot conclusions, evidence, review state, fingerprints, release IDs, or any existing claims/evidence data.

## Evidence and data boundary

- [x] This change preserves the candidate, review, and public-release boundary.
- [x] Data changes retain source URL, source language, snapshot hash, evidence, confidence, review state, and source-rights caveat where applicable.
- [x] No full third-party HTML, PDF, screenshot, syllabus, LMS page, or private source material has been added to the repository.

The fix changes only response URL construction. It does not promote or mutate `data/public-releases/current.json`, and it does not mutate the existing claims/evidence public release chain. No dataset tag or GitHub Release is required for this follow-up.

## Validation

- [x] I ran the relevant validator, test, typecheck, or build command.
- [x] I ran `git diff --check`.
- [x] I checked that no secret, credential, private log, or personal data is in the diff.

Validation on exact commit `ccb6db8`:

- `pnpm test:policy-snapshot` passed (6 tests).
- `pnpm test:policy-snapshot-review` passed (4 tests).
- `pnpm smoke:policy-snapshot` passed (24 indexed snapshots, 17 strong).
- `pnpm check` passed.
- `UAPT_DISABLE_INTERNAL_FETCH=1 pnpm --filter @uapt/web build` passed and generated 5,214 static pages.
- `git diff --check` passed.

## Release and deployment

- [x] This PR does not deploy production or change production settings.
- [x] The public API URL fix and intentional omission of `data/public-releases/current.json` promotion are explained above.
